### PR TITLE
docs: improve wording, add SSH method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ In this repository, various exercises for practicing Git and GitHub skills may b
 
 ## Prerequisites
 
-[Install](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) Git on your device.
+1. [Install](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) Git on your device.
+2. Create a GitHub account.
+3. (optional) If you wish to use the SSH clone method, upload your SSH public key to GitHub.
 
 ## Setup
 
-Clone this repository using [HTTPS](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls).
+Download this repository using [HTTPS](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls).
+Alternatively using [SSH](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-ssh-urls)
 
 ```bash
 git clone https://github.com/flowup/git-workshop.git


### PR DESCRIPTION
Closes #7 
In this PR, I am expanding the main `README` documentation by describing the SSH cloning method.